### PR TITLE
CLOSES #3: Update source image to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 2.
 
 CentOS-7 7.5.1804 x86_64 - Redis 4.0.
 
+### 2.0.1 - Unreleased
+
+- Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).
+
 ### 2.0.0 - 2018-11-03
 
 - Initial release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # =============================================================================
 # jdeathe/centos-ssh-redis
 #
-# CentOS-6, Redis 4.0.
+# CentOS-7, Redis 4.0.
 # =============================================================================
-FROM jdeathe/centos-ssh:2.4.0
+FROM jdeathe/centos-ssh:2.4.1
 
 RUN yum -y install \
 			--setopt=tsflags=nodocs \


### PR DESCRIPTION
CLOSES #3

- Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).