### PR TITLE
CLOSES #4: Update source image to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.10 x86_64 - Redis 3.2.
 
+### 1.0.1 - Unreleased
+
+- Updates source image to [1.9.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.1).
+
 ### 1.0.0 - 2018-11-03
 
 - Initial release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # CentOS-6, Redis 3.2.
 # =============================================================================
-FROM jdeathe/centos-ssh:1.9.0
+FROM jdeathe/centos-ssh:1.9.1
 
 RUN yum -y install \
 			--setopt=tsflags=nodocs \


### PR DESCRIPTION
CLOSES #4

- Updates source image to [1.9.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.1).