### PR TITLE
CLOSES #17: Adds improved logging output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ CentOS-6 6.10 x86_64 - Redis 3.2.
 - Adds consideration for event lag into test cases for unhealthy health_status events.
 - Adds port incrementation to Makefile's run template for container names with an instance suffix.
 - Adds docker-compose configuration example.
+- Adds improved logging output.
 - Removes use of `/etc/services-config` paths.
 - Removes X-Fleet section from etcd register template unit-file.
 - Removes the unused group element from the default container name.
 - Removes the node element from the default container name.
 - Removes unused environment variables from Makefile and scmi configuration.
+- Removes container log file `/var/log/redis-server-bootstrap` and `/var/log/redis/redis.log`.
 
 ### 1.0.1 - 2018-11-19
 

--- a/environment.mk
+++ b/environment.mk
@@ -33,7 +33,7 @@ NO_CACHE ?= false
 DIST_PATH ?= ./dist
 
 # Number of seconds expected to complete container startup including bootstrap.
-STARTUP_TIME ?= 2
+STARTUP_TIME ?= 1
 
 # ------------------------------------------------------------------------------
 # Application container configuration

--- a/src/etc/supervisord.d/redis-server-bootstrap.conf
+++ b/src/etc/supervisord.d/redis-server-bootstrap.conf
@@ -6,5 +6,5 @@ startsecs = 0
 startretries = 0
 autorestart = false
 redirect_stderr = true
-stdout_logfile = /var/log/redis-server-bootstrap
-stdout_events_enabled = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0

--- a/src/etc/supervisord.d/redis-server-wrapper.conf
+++ b/src/etc/supervisord.d/redis-server-wrapper.conf
@@ -2,9 +2,9 @@
 priority = 100
 command = /usr/sbin/redis-server-wrapper
 autostart = %(ENV_REDIS_AUTOSTART_REDIS_WRAPPER)s
-startsecs = 1
+startsecs = 0
 autorestart = true
 redirect_stderr = true
-stdout_logfile = /var/log/redis/redis.log
-stdout_events_enabled = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 user = redis

--- a/src/opt/scmi/environment.sh
+++ b/src/opt/scmi/environment.sh
@@ -27,7 +27,7 @@ NO_CACHE="${NO_CACHE:-false}"
 DIST_PATH="${DIST_PATH:-./dist}"
 
 # Number of seconds expected to complete container startup including bootstrap.
-STARTUP_TIME="${STARTUP_TIME:-2}"
+STARTUP_TIME="${STARTUP_TIME:-1}"
 
 # Docker --sysctl settings
 SYSCTL_NET_CORE_SOMAXCONN="${SYSCTL_NET_CORE_SOMAXCONN:-1024}"

--- a/src/opt/scmi/service-unit.sh
+++ b/src/opt/scmi/service-unit.sh
@@ -27,4 +27,4 @@ readonly SERVICE_UNIT_REGISTER_ENVIRONMENT_KEYS="
 # ------------------------------------------------------------------------------
 # Variables
 # ------------------------------------------------------------------------------
-SERVICE_UNIT_INSTALL_TIMEOUT="${SERVICE_UNIT_INSTALL_TIMEOUT:-5}"
+SERVICE_UNIT_INSTALL_TIMEOUT="${SERVICE_UNIT_INSTALL_TIMEOUT:-4}"

--- a/src/usr/sbin/redis-server-bootstrap
+++ b/src/usr/sbin/redis-server-bootstrap
@@ -4,8 +4,6 @@ set -e
 
 readonly CONFIG_PATH="/etc/redis.conf"
 readonly LOCK_FILE="/var/lock/subsys/redis-server-bootstrap"
-readonly LOG_FILE="/var/log/redis/redis.log"
-readonly OPTIONS="${REDIS_OPTIONS:-}"
 readonly TIMER_START="$(
 	date +%s.%N
 )"
@@ -33,26 +31,6 @@ function load_config ()
 	fi
 }
 
-function set_log_write_user ()
-{
-	local file_path="${1:-}"
-	local user="${2:-}"
-
-	if [[ ! -f ${file_path} ]]
-	then
-		touch \
-			"${file_path}"
-	fi
-
-	chown \
-		"${user}":"${user}" \
-		"${file_path}"
-
-	chmod \
-		0660 \
-		"${file_path}"
-}
-
 function set_wrapper_execute_user ()
 {
 	local file_path="${1:-}"
@@ -69,10 +47,6 @@ function set_wrapper_execute_user ()
 
 set_wrapper_execute_user \
 	"${WRAPPER}" \
-	"${USER}"
-
-set_log_write_user \
-	"${LOG_FILE}" \
 	"${USER}"
 
 load_config \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1,4 +1,4 @@
-readonly STARTUP_TIME=2
+readonly STARTUP_TIME=1
 readonly TEST_DIRECTORY="test"
 
 # These should ideally be a static value but hosts might be using this port so 


### PR DESCRIPTION
CLOSES #17: Patches back #16.

- Adds improved logging output.
- Removes container log file `/var/log/redis-server-bootstrap` and `/var/log/redis/redis.log`.