### PR TITLE
CLOSES #36: Updates upstream source to 2.5.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Summary of release changes for Version 2.
 
 CentOS-7 7.5.1804 x86_64 - Redis 4.0.
 
+### 2.1.1 - Unreleased
+
+- Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
+- Updates Dockerfile with combined ADD to reduce layer count in final image.
+- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
+- Adds improvement to pull logic in systemd unit install template.
+- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
+- Adds improved `healtchcheck` script.
+
 ### 2.1.0 - 2019-02-17
 
 - Updates source image to [2.5.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.0).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jdeathe/centos-ssh:2.5.0
+FROM jdeathe/centos-ssh:2.5.1
 
 ARG RELEASE_VERSION="2.1.0"
 
@@ -16,12 +16,7 @@ RUN yum -y install \
 # ------------------------------------------------------------------------------
 # Copy files into place
 # ------------------------------------------------------------------------------
-ADD src/etc \
-	/etc/
-ADD src/opt/scmi \
-	/opt/scmi/
-ADD src/usr \
-	/usr/
+ADD src /
 
 # ------------------------------------------------------------------------------
 # Provisioning
@@ -62,7 +57,8 @@ ENV REDIS_AUTOSTART_REDIS_BOOTSTRAP="true" \
 	REDIS_OPTIONS="" \
 	REDIS_TCP_BACKLOG="1024" \
 	SSH_AUTOSTART_SSHD="false" \
-	SSH_AUTOSTART_SSHD_BOOTSTRAP="false"
+	SSH_AUTOSTART_SSHD_BOOTSTRAP="false" \
+	SSH_AUTOSTART_SUPERVISOR_STDOUT="false"
 
 # ------------------------------------------------------------------------------
 # Set image metadata

--- a/src/etc/supervisord.d/redis-server-bootstrap.conf
+++ b/src/etc/supervisord.d/redis-server-bootstrap.conf
@@ -1,10 +1,10 @@
 [program:redis-server-bootstrap]
-priority = 6
-command = /usr/sbin/redis-server-bootstrap --verbose
+autorestart = false
 autostart = %(ENV_REDIS_AUTOSTART_REDIS_BOOTSTRAP)s
+command = /usr/sbin/redis-server-bootstrap --verbose
+priority = 6
+redirect_stderr = true
 startsecs = 0
 startretries = 0
-autorestart = false
-redirect_stderr = true
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0

--- a/src/etc/supervisord.d/redis-server-wrapper.conf
+++ b/src/etc/supervisord.d/redis-server-wrapper.conf
@@ -1,10 +1,10 @@
 [program:redis-server-wrapper]
-priority = 100
-command = /usr/sbin/redis-server-wrapper
-autostart = %(ENV_REDIS_AUTOSTART_REDIS_WRAPPER)s
-startsecs = 0
 autorestart = true
+autostart = %(ENV_REDIS_AUTOSTART_REDIS_WRAPPER)s
+command = /usr/sbin/redis-server-wrapper
+priority = 100
 redirect_stderr = true
+startsecs = 0
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 user = redis

--- a/src/etc/systemd/system/centos-ssh-redis.register@.service
+++ b/src/etc/systemd/system/centos-ssh-redis.register@.service
@@ -35,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo systemctl daemon-reload
 # ------------------------------------------------------------------------------
@@ -91,7 +92,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             6379 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -104,7 +105,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             6379 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -129,15 +130,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/tcp/6379 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set\n'; \
         else \
-          echo update; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/tcp/6379 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             6379 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
       /usr/bin/etcdctl \
@@ -148,15 +149,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/udp/6379 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set\n'; \
         else \
-          echo update; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/udp/6379 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             6379 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
     fi; \
@@ -168,9 +169,9 @@ ExecStart=/bin/bash -c \
           ${REGISTER_KEY_ROOT}/hostname \
         &> /dev/null; \
       then \
-        echo set; \
+        printf -- 'set\n'; \
       else \
-        echo update; \
+        printf -- 'update\n'; \
       fi) \
       ${REGISTER_KEY_ROOT}/hostname \
       %H \

--- a/src/etc/systemd/system/centos-ssh-redis@.service
+++ b/src/etc/systemd/system/centos-ssh-redis@.service
@@ -26,7 +26,8 @@
 #     sudo systemctl enable -f {service-unit-instance-name}
 #
 # Start using:
-#     sudo systemctl [start|stop|restart|kill|status] {service-unit-instance-name}
+#     sudo systemctl [start|stop|restart|kill|status] \
+#       {service-unit-instance-name}
 #
 # Debugging:
 #     sudo systemctl status {service-unit-instance-name}
@@ -34,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo systemctl stop {service-unit-instance-name}
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo docker rm -f {service-unit-long-name}
@@ -68,20 +70,12 @@ Environment="SYSCTL_NET_IPV4_ROUTE_FLUSH=1"
 
 # Initialisation: Load image from local storage if available, otherwise pull.
 ExecStartPre=/bin/bash -c \
-  "if [[ -z $( \
-      if [[ -n $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ) ]]; \
-      then \
-        echo $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      else \
-        echo $(/usr/bin/docker images -q \
-          docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      fi; \
-    ) ]]; \
+  "if [[ -z \"$(/usr/bin/docker images -q \
+      ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]] \
+    && [[ -z \"$(/usr/bin/docker images -q \
+      docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]]; \
   then \
     if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; \
     then \
@@ -146,7 +140,7 @@ ExecStart=/bin/bash -c \
           <<< \"${DOCKER_PORT_MAP_TCP_6379}\"; \
         && /usr/bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< "${DOCKER_NAME}"
+          <<< %p.%i; \
       then \
         printf -- '--publish %%s%%s:6379/tcp' \
           $(\

--- a/src/usr/bin/healthcheck
+++ b/src/usr/bin/healthcheck
@@ -2,35 +2,38 @@
 
 set -e
 
-if ! ps axo command | grep -qE '^/usr/bin/python /usr/bin/supervisord'
-then
-	>&2 printf -- \
-		'%s\n' \
-		"supervisord not running."
-	exit 1
-fi
+function main ()
+{
+	if ! ps axo command | grep -qE '^/usr/bin/python /usr/bin/supervisord'
+	then
+		>&2 printf -- \
+			'%s\n' \
+			"supervisord not running."
+		exit 1
+	fi
 
-# Client only mode
-if [[ ! ${REDIS_AUTOSTART_REDIS_BOOTSTRAP} == true ]] \
-	|| [[ ! ${REDIS_AUTOSTART_REDIS_WRAPPER} == true ]]
-then
-	exit 0
-fi
+	# Client only mode
+	if [[ ! ${REDIS_AUTOSTART_REDIS_BOOTSTRAP} == true ]] \
+		|| [[ ! ${REDIS_AUTOSTART_REDIS_WRAPPER} == true ]]
+	then
+		exit 0
+	fi
 
-if ! ps axo command | grep -qE '^/usr/bin/redis-server'
-then
-	>&2 printf -- \
-		'%s\n' \
-		"redis-server not running."
-	exit 1
-fi
+	if ! ps axo command | grep -qE '^/usr/bin/redis-server'
+	then
+		>&2 printf -- \
+			'%s\n' \
+			"redis-server not running."
+		exit 1
+	fi
 
-if ! redis-cli PING | grep -qE '^PONG$'
-then
-	>&2 printf -- \
-		'%s\n' \
-		"redis-server not responding."
-	exit 1
-fi
+	if ! redis-cli PING | grep -qE '^PONG$'
+	then
+		>&2 printf -- \
+			'%s\n' \
+			"redis-server not responding."
+		exit 1
+	fi
+}
 
-exit 0
+main "${@}"


### PR DESCRIPTION
CLOSES #36

- Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
- Updates Dockerfile with combined ADD to reduce layer count in final image.
- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
- Adds improvement to pull logic in systemd unit install template.
- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
- Adds improved `healtchcheck` script.