### PR TITLE
CLOSES #35: Disables disk persistence by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CentOS-6 6.10 x86_64 - Redis 3.2.
 - Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
 - Adds improved `healtchcheck` script.
 - Adds `docker-compose.yml` to `.dockerignore`.
+- Disables disk persistence by default; primary use-case being an LRU cache.
 
 ### 1.1.0 - 2019-02-17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ADD src /
 RUN sed -i -r \
 		-e "s~^(logfile ).+$~\1\"\"~" \
 		-e "s~^(bind ).+$~\10.0.0.0~" \
+		-e "s~^(save [0-9]+ [0-9]+)~#\1~" \
 		-e "s~^(# *)?(maxmemory ).+$~\2{{REDIS_MAXMEMORY}}~" \
 		-e "s~^(# *)?(maxmemory-policy ).+$~\2{{REDIS_MAXMEMORY_POLICY}}~" \
 		-e "s~^(# *)?(maxmemory-samples ).+$~\2{{REDIS_MAXMEMORY_SAMPLES}}~" \

--- a/src/usr/sbin/redis-server-bootstrap
+++ b/src/usr/sbin/redis-server-bootstrap
@@ -259,10 +259,10 @@ function main ()
 			Redis Details
 			--------------------------------------------------------------------------------
 			maxmemory : ${redis_maxmemory}
-			maxmemory-policy: ${redis_maxmemory_policy}
-			maxmemory-samples: ${redis_maxmemory_samples}
-			tcp-backlog: ${redis_tcp_backlog}
-			redis-server options: ${redis_options}
+			maxmemory-policy : ${redis_maxmemory_policy}
+			maxmemory-samples : ${redis_maxmemory_samples}
+			tcp-backlog : ${redis_tcp_backlog}
+			redis-server options : ${redis_options}
 			--------------------------------------------------------------------------------
 			${timer_total}
 


### PR DESCRIPTION
CLOSES #35: Patches back #33.

- Disables disk persistence by default; primary use-case being an LRU cache.