### PR TITLE
CLOSES #46: Adds notice about Version 3/4 and corresponding Redis versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CentOS-7 7.5.1804 x86_64 - Redis 4.0.
 
 ### 2.1.1 - Unreleased
 
+- **Notice: This will be the last Version 2 release. The Version 3 release will be based on EPEL `redis` packages (i.e Redis 3.2). Version 4 will be based on IUS `redis40u` packages (i.e Redis 4.0).**
 - Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
 - Updates Dockerfile with combined ADD to reduce layer count in final image.
 - Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.


### PR DESCRIPTION
CLOSES #46

 **Notice: This will be the last Version 2 release. The Version 3 release will be based on EPEL `redis` packages (i.e Redis 3.2). Version 4 will be based on IUS `redis40u` packages (i.e Redis 4.0).**