### PR TITLE
Release changes for 1.1.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 .gitignore
 dist
 test
+docker-compose.yml
 LICENSE
 README-short.txt
 *.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.10 x86_64 - Redis 3.2.
 
+### 1.1.1 - Unreleased
+
+- Updates source image to [1.10.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.1).
+- Updates Dockerfile with combined ADD to reduce layer count in final image.
+- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
+- Adds improvement to pull logic in systemd unit install template.
+- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
+- Adds improved `healtchcheck` script.
+
 ### 1.1.0 - 2019-02-17
 
 - Updates source image to [1.10.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.10 x86_64 - Redis 3.2.
 ### 1.1.1 - Unreleased
 
 - Updates source image to [1.10.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.1).
+- Updates Redis package to `redis-3.2.12-2` from the EPEL repository.
 - Updates Dockerfile with combined ADD to reduce layer count in final image.
 - Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
 - Adds improvement to pull logic in systemd unit install template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.10 x86_64 - Redis 3.2.
 
-### 1.1.1 - Unreleased
+### 1.1.1 - 2019-03-21
 
 - Updates source image to [1.10.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.1).
 - Updates Redis package to `redis-3.2.12-2` from the EPEL repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CentOS-6 6.10 x86_64 - Redis 3.2.
 - Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
 - Adds improved `healtchcheck` script.
 - Adds `docker-compose.yml` to `.dockerignore`.
+- Disables disk persistence by default; primary use-case being an LRU cache.
 
 ### 1.1.0 - 2019-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CentOS-6 6.10 x86_64 - Redis 3.2.
 - Adds improvement to pull logic in systemd unit install template.
 - Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
 - Adds improved `healtchcheck` script.
+- Adds `docker-compose.yml` to `.dockerignore`.
 
 ### 1.1.0 - 2019-02-17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jdeathe/centos-ssh:1.10.0
+FROM jdeathe/centos-ssh:1.10.1
 
 ARG RELEASE_VERSION="1.1.0"
 
@@ -13,12 +13,7 @@ RUN yum -y install \
 # ------------------------------------------------------------------------------
 # Copy files into place
 # ------------------------------------------------------------------------------
-ADD src/etc \
-	/etc/
-ADD src/opt/scmi \
-	/opt/scmi/
-ADD src/usr \
-	/usr/
+ADD src /
 
 # ------------------------------------------------------------------------------
 # Provisioning
@@ -59,7 +54,8 @@ ENV REDIS_AUTOSTART_REDIS_BOOTSTRAP="true" \
 	REDIS_OPTIONS="" \
 	REDIS_TCP_BACKLOG="1024" \
 	SSH_AUTOSTART_SSHD="false" \
-	SSH_AUTOSTART_SSHD_BOOTSTRAP="false"
+	SSH_AUTOSTART_SSHD_BOOTSTRAP="false" \
+	SSH_AUTOSTART_SUPERVISOR_STDOUT="false"
 
 # -----------------------------------------------------------------------------
 # Set image metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ADD src /
 RUN sed -i -r \
 		-e "s~^(logfile ).+$~\1\"\"~" \
 		-e "s~^(bind ).+$~\10.0.0.0~" \
+		-e "s~^(save [0-9]+ [0-9]+)~#\1~" \
 		-e "s~^(# *)?(maxmemory ).+$~\2{{REDIS_MAXMEMORY}}~" \
 		-e "s~^(# *)?(maxmemory-policy ).+$~\2{{REDIS_MAXMEMORY_POLICY}}~" \
 		-e "s~^(# *)?(maxmemory-samples ).+$~\2{{REDIS_MAXMEMORY_SAMPLES}}~" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ ARG RELEASE_VERSION="1.1.0"
 RUN yum -y install \
 			--setopt=tsflags=nodocs \
 			--disableplugin=fastestmirror \
-			--enablerepo=ius-archive \
-		redis32u-3.2.12-1.ius.centos6 \
+		redis-3.2.12-2.el6 \
 	&& yum versionlock add \
-		redis32u* \
+		redis* \
 	&& yum clean all
 
 # ------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG RELEASE_VERSION="1.1.0"
 RUN yum -y install \
 			--setopt=tsflags=nodocs \
 			--disableplugin=fastestmirror \
+			--enablerepo=ius-archive \
 		redis32u-3.2.12-1.ius.centos6 \
 	&& yum versionlock add \
 		redis32u* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jdeathe/centos-ssh:1.10.1
 
-ARG RELEASE_VERSION="1.1.0"
+ARG RELEASE_VERSION="1.1.1"
 
 RUN yum -y install \
 			--setopt=tsflags=nodocs \

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Docker Image including:
 
 ## Overview & links
 
-The latest CentOS-6 / CentOS-7 based releases can be pulled from the `centos-6` / `centos-7` Docker tags respectively. For production use it is recommended to select a specific release tag - the convention is `centos-6-1.1.0` OR `1.1.0` for the [1.1.0](https://github.com/jdeathe/centos-ssh-redis/tree/1.1.0) release tag and `centos-7-2.1.0` OR `2.1.0` for the [2.1.0](https://github.com/jdeathe/centos-ssh-redis/tree/2.1.0) release tag.
+The latest CentOS-6 / CentOS-7 based releases can be pulled from the `centos-6` / `centos-7` Docker tags respectively. For production use it is recommended to select a specific release tag - the convention is `centos-6-1.1.1` OR `1.1.1` for the [1.1.1](https://github.com/jdeathe/centos-ssh-redis/tree/1.1.1) release tag and `centos-7-2.1.1` OR `2.1.1` for the [2.1.1](https://github.com/jdeathe/centos-ssh-redis/tree/2.1.1) release tag.
 
 ### Tags and respective `Dockerfile` links
 
-- `centos-7`,`centos-7-2.1.0`,`2.1.0` [(centos-7/Dockerfile)](https://github.com/jdeathe/centos-ssh-redis/blob/centos-7/Dockerfile)
-- `centos-6`,`centos-6-1.1.0`,`1.1.0` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-redis/blob/centos-6/Dockerfile)
+- `centos-7`,`centos-7-2.1.1`,`2.1.1` [(centos-7/Dockerfile)](https://github.com/jdeathe/centos-ssh-redis/blob/centos-7/Dockerfile)
+- `centos-6`,`centos-6-1.1.1`,`1.1.1` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-redis/blob/centos-6/Dockerfile)
 
 Included in the build are the [SCL](https://www.softwarecollections.org/), [EPEL](http://fedoraproject.org/wiki/EPEL) and [IUS](https://ius.io) repositories. Installed packages include [OpenSSH](http://www.openssh.com/portable.html) secure shell, [vim-minimal](http://www.vim.org/), are installed along with python-setuptools, [supervisor](http://supervisord.org/) and [supervisor-stdout](https://github.com/coderanger/supervisor-stdout).
 
@@ -40,7 +40,7 @@ $ docker run -d \
   --name redis.1 \
   -p 6379:6379/tcp \
   --sysctl "net.core.somaxconn=2048" \
-  jdeathe/centos-ssh-redis:1.1.0
+  jdeathe/centos-ssh-redis:1.1.1
 ```
 
 Now you can verify it is initialised and running successfully by inspecting the container's logs.
@@ -74,7 +74,7 @@ $ docker run \
   --env "REDIS_MAXMEMORY_SAMPLES=10" \
   --env "REDIS_OPTIONS=--loglevel verbose" \
   --env "REDIS_TCP_BACKLOG=2048" \
-  jdeathe/centos-ssh-redis:1.1.0
+  jdeathe/centos-ssh-redis:1.1.1
 ```
 
 #### Environment Variables

--- a/src/etc/supervisord.d/redis-server-bootstrap.conf
+++ b/src/etc/supervisord.d/redis-server-bootstrap.conf
@@ -1,10 +1,10 @@
 [program:redis-server-bootstrap]
-priority = 6
-command = /usr/sbin/redis-server-bootstrap --verbose
+autorestart = false
 autostart = %(ENV_REDIS_AUTOSTART_REDIS_BOOTSTRAP)s
+command = /usr/sbin/redis-server-bootstrap --verbose
+priority = 6
+redirect_stderr = true
 startsecs = 0
 startretries = 0
-autorestart = false
-redirect_stderr = true
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0

--- a/src/etc/supervisord.d/redis-server-wrapper.conf
+++ b/src/etc/supervisord.d/redis-server-wrapper.conf
@@ -1,10 +1,10 @@
 [program:redis-server-wrapper]
-priority = 100
-command = /usr/sbin/redis-server-wrapper
-autostart = %(ENV_REDIS_AUTOSTART_REDIS_WRAPPER)s
-startsecs = 0
 autorestart = true
+autostart = %(ENV_REDIS_AUTOSTART_REDIS_WRAPPER)s
+command = /usr/sbin/redis-server-wrapper
+priority = 100
 redirect_stderr = true
+startsecs = 0
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 user = redis

--- a/src/etc/systemd/system/centos-ssh-redis.register@.service
+++ b/src/etc/systemd/system/centos-ssh-redis.register@.service
@@ -35,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo systemctl daemon-reload
 # ------------------------------------------------------------------------------
@@ -91,7 +92,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             6379 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -104,7 +105,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             6379 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -129,15 +130,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/tcp/6379 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set\n'; \
         else \
-          echo update; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/tcp/6379 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             6379 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
       /usr/bin/etcdctl \
@@ -148,15 +149,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/udp/6379 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set\n'; \
         else \
-          echo update; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/udp/6379 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             6379 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
     fi; \
@@ -168,9 +169,9 @@ ExecStart=/bin/bash -c \
           ${REGISTER_KEY_ROOT}/hostname \
         &> /dev/null; \
       then \
-        echo set; \
+        printf -- 'set\n'; \
       else \
-        echo update; \
+        printf -- 'update\n'; \
       fi) \
       ${REGISTER_KEY_ROOT}/hostname \
       %H \

--- a/src/etc/systemd/system/centos-ssh-redis@.service
+++ b/src/etc/systemd/system/centos-ssh-redis@.service
@@ -26,7 +26,8 @@
 #     sudo systemctl enable -f {service-unit-instance-name}
 #
 # Start using:
-#     sudo systemctl [start|stop|restart|kill|status] {service-unit-instance-name}
+#     sudo systemctl [start|stop|restart|kill|status] \
+#       {service-unit-instance-name}
 #
 # Debugging:
 #     sudo systemctl status {service-unit-instance-name}
@@ -34,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo systemctl stop {service-unit-instance-name}
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo docker rm -f {service-unit-long-name}
@@ -68,20 +70,12 @@ Environment="SYSCTL_NET_IPV4_ROUTE_FLUSH=1"
 
 # Initialisation: Load image from local storage if available, otherwise pull.
 ExecStartPre=/bin/bash -c \
-  "if [[ -z $( \
-      if [[ -n $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ) ]]; \
-      then \
-        echo $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      else \
-        echo $(/usr/bin/docker images -q \
-          docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      fi; \
-    ) ]]; \
+  "if [[ -z \"$(/usr/bin/docker images -q \
+      ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]] \
+    && [[ -z \"$(/usr/bin/docker images -q \
+      docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]]; \
   then \
     if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; \
     then \
@@ -146,7 +140,7 @@ ExecStart=/bin/bash -c \
           <<< \"${DOCKER_PORT_MAP_TCP_6379}\"; \
         && /usr/bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< "${DOCKER_NAME}"
+          <<< %p.%i; \
       then \
         printf -- '--publish %%s%%s:6379/tcp' \
           $(\

--- a/src/usr/bin/healthcheck
+++ b/src/usr/bin/healthcheck
@@ -2,35 +2,38 @@
 
 set -e
 
-if ! ps axo command | grep -qE '^/usr/bin/python /usr/bin/supervisord'
-then
-	>&2 printf -- \
-		'%s\n' \
-		"supervisord not running."
-	exit 1
-fi
+function main ()
+{
+	if ! ps axo command | grep -qE '^/usr/bin/python /usr/bin/supervisord'
+	then
+		>&2 printf -- \
+			'%s\n' \
+			"supervisord not running."
+		exit 1
+	fi
 
-# Client only mode
-if [[ ! ${REDIS_AUTOSTART_REDIS_BOOTSTRAP} == true ]] \
-	|| [[ ! ${REDIS_AUTOSTART_REDIS_WRAPPER} == true ]]
-then
-	exit 0
-fi
+	# Client only mode
+	if [[ ! ${REDIS_AUTOSTART_REDIS_BOOTSTRAP} == true ]] \
+		|| [[ ! ${REDIS_AUTOSTART_REDIS_WRAPPER} == true ]]
+	then
+		exit 0
+	fi
 
-if ! ps axo command | grep -qE '^/usr/bin/redis-server'
-then
-	>&2 printf -- \
-		'%s\n' \
-		"redis-server not running."
-	exit 1
-fi
+	if ! ps axo command | grep -qE '^/usr/bin/redis-server'
+	then
+		>&2 printf -- \
+			'%s\n' \
+			"redis-server not running."
+		exit 1
+	fi
 
-if ! redis-cli PING | grep -qE '^PONG$'
-then
-	>&2 printf -- \
-		'%s\n' \
-		"redis-server not responding."
-	exit 1
-fi
+	if ! redis-cli PING | grep -qE '^PONG$'
+	then
+		>&2 printf -- \
+			'%s\n' \
+			"redis-server not responding."
+		exit 1
+	fi
+}
 
-exit 0
+main "${@}"

--- a/src/usr/sbin/redis-server-bootstrap
+++ b/src/usr/sbin/redis-server-bootstrap
@@ -259,10 +259,10 @@ function main ()
 			Redis Details
 			--------------------------------------------------------------------------------
 			maxmemory : ${redis_maxmemory}
-			maxmemory-policy: ${redis_maxmemory_policy}
-			maxmemory-samples: ${redis_maxmemory_samples}
-			tcp-backlog: ${redis_tcp_backlog}
-			redis-server options: ${redis_options}
+			maxmemory-policy : ${redis_maxmemory_policy}
+			maxmemory-samples : ${redis_maxmemory_samples}
+			tcp-backlog : ${redis_tcp_backlog}
+			redis-server options : ${redis_options}
 			--------------------------------------------------------------------------------
 			${timer_total}
 


### PR DESCRIPTION
- Updates source image to [1.10.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.1).
- Updates Redis package to `redis-3.2.12-2` from the EPEL repository.
- Updates Dockerfile with combined ADD to reduce layer count in final image.
- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
- Adds improvement to pull logic in systemd unit install template.
- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
- Adds improved `healtchcheck` script.
- Adds `docker-compose.yml` to `.dockerignore`.
- Disables disk persistence by default; primary use-case being an LRU cache.